### PR TITLE
include celery in commcare exporter targets

### DIFF
--- a/roles/prometheus/templates/targets/commcare_exporter_target.json.j2
+++ b/roles/prometheus/templates/targets/commcare_exporter_target.json.j2
@@ -1,7 +1,7 @@
 [
   {
     "targets": [
-      {%- for item in (groups.webworkers + groups.pillowtop)|sort -%}
+      {%- for item in (groups.webworkers + groups.pillowtop + groups.celery)|sort -%}
       "{{ hostvars[item].alt_hostname | default(hostvars[item].hostname) }}:9011"{% if not loop.last %},{% endif %}
       {%- endfor -%}
     ],


### PR DESCRIPTION
Some celery workers have processes that export metrics
e.g. submission reporocessing queue